### PR TITLE
Adding load balancer and app install to sample AZ templates

### DIFF
--- a/preview/zones/multizone.json
+++ b/preview/zones/multizone.json
@@ -37,8 +37,17 @@
     "ipConfigName": "[concat(parameters('vmssName'), 'ipconfig')]",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",
-    "storageAccountType": "Standard_LRS",
     "location": "[resourceGroup().location]",
+    "publicIPAddressName": "[concat(parameters('vmssName'), 'publicip')]",
+    "networkSecurityGroupName": "[concat(parameters('vmssName'), 'nsg')]",
+    "loadBalancerName": "[concat(parameters('vmssName'), 'lb')]",
+    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
+    "natPoolName": "[concat(parameters('vmssName'), 'natpool')]",
+    "bePoolName": "[concat(parameters('vmssName'), 'bepool')]",
+    "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/',variables('bePoolName'))]",
+    "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]",
+    "frontEndIPConfigID": "[concat(variables('lbID'), '/frontendIPConfigurations/loadBalancerFrontEnd')]",
     "osType": {
       "publisher": "Canonical",
       "offer": "UbuntuServer",
@@ -46,13 +55,54 @@
       "version": "latest"
     },
     "imageReference": "[variables('osType')]",
-    "computeApiVersion": "2017-03-30",
-    "networkApiVersion": "2017-04-01"
+    "computeApiVersion": "2017-12-01",
+    "networkApiVersion": "2017-10-01"
   },
   "resources": [
     {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[variables('location')]",
+      "properties": {
+          "securityRules": [
+              {
+                  "name": "allowSSH",
+                  "properties": {
+                      "description": "Allow SSH traffic",
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "22",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 1000,
+                      "direction": "Inbound"
+                  }
+              },
+              {
+                  "name": "allowHTTP",
+                  "properties": {
+                      "description": "Allow web traffic",
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "80",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 1001,
+                      "direction": "Inbound"
+                  }
+              }
+          ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]"
+      ],
       "location": "[variables('location')]",
       "apiVersion": "[variables('networkApiVersion')]",
       "properties": {
@@ -65,10 +115,103 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "sku": {
+          "name": "Standard"
+      },
+      "properties": {
+          "publicIPAllocationMethod": "Static",
+          "dnsSettings": {
+              "domainNameLabel": "[parameters('vmssName')]"
+          }
+      }
+    },
+    {
+      "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "name": "[variables('loadBalancerName')]",
+      "location": "[variables('location')]",
+      "sku": {
+          "name": "Standard"
+      },
+      "dependsOn": [
+          "[variables('publicIPAddressName')]"
+      ],
+      "properties": {
+          "frontendIPConfigurations": [
+              {
+                  "name": "LoadBalancerFrontEnd",
+                  "properties": {
+                      "publicIPAddress": {
+                          "id": "[variables('publicIPAddressID')]"
+                      }
+                  }
+              }
+          ],
+          "backendAddressPools": [
+              {
+                  "name": "[variables('bePoolName')]"
+              }
+          ],
+          "probes": [
+            {
+              "name": "tcpProbe",
+              "properties": {
+                "protocol": "tcp",
+                "port": 80,
+                "intervalInSeconds": 5,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "LBRule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "[variables('frontEndIPConfigID')]"
+                },
+                "backendAddressPool": {
+                  "id": "[variables('lbPoolID')]"
+                },
+                "protocol": "tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": false,
+                "idleTimeoutInMinutes": 5,
+                "probe": {
+                  "id": "[variables('lbProbeID')]"
+                }
+              }
+            }
+          ],
+          "inboundNatPools": [
+              {
+                  "name": "[variables('natPoolName')]",
+                  "properties": {
+                      "frontendIPConfiguration": {
+                          "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPortRangeStart": "50000",
+                      "frontendPortRangeEnd": "50100",
+                      "backendPort": "22"
+                  }
+              }
+          ]
       }
     },
     {
@@ -82,7 +225,8 @@
       ],
       "apiVersion": "[variables('computeApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]"
       ],
       "sku": {
         "name": "[variables('vmSize')]",
@@ -91,7 +235,7 @@
       },
       "properties": {
         "upgradePolicy": {
-          "mode": "Manual"
+          "mode": "Automatic"
         },
         "virtualMachineProfile": {
           "storageProfile": {
@@ -118,10 +262,39 @@
                       "properties": {
                         "subnet": {
                           "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'), '/subnets/', variables('subnetName'))]"
-                        }
+                        },
+                        "loadBalancerBackendAddressPools": [
+                          {
+                              "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('bePoolName'))]"
+                          }
+                        ],
+                        "loadBalancerInboundNatPools": [
+                            {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools/', variables('loadBalancerName'), variables('natPoolName'))]"
+                            }
+                        ]
                       }
                     }
                   ]
+                }
+              }
+            ]
+          },
+          "extensionProfile": {
+            "extensions": [
+              {
+                "name": "AppInstall",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0",
+                  "autoUpgradeMinorVersion": true,
+                  "settings": {
+                    "fileUris": [
+                      "https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"
+                    ],
+                    "commandToExecute": "bash automate_nginx.sh"
+                  }
                 }
               }
             ]

--- a/preview/zones/singlezone.json
+++ b/preview/zones/singlezone.json
@@ -43,7 +43,16 @@
     "ipConfigName": "[concat(parameters('vmssName'), 'ipconfig')]",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",
-    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "[concat(parameters('vmssName'), 'publicip')]",
+    "networkSecurityGroupName": "[concat(parameters('vmssName'), 'nsg')]",
+    "loadBalancerName": "[concat(parameters('vmssName'), 'lb')]",
+    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
+    "natPoolName": "[concat(parameters('vmssName'), 'natpool')]",
+    "bePoolName": "[concat(parameters('vmssName'), 'bepool')]",
+    "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/',variables('bePoolName'))]",
+    "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]",
+    "frontEndIPConfigID": "[concat(variables('lbID'), '/frontendIPConfigurations/loadBalancerFrontEnd')]",
     "location": "[resourceGroup().location]",
     "osType": {
       "publisher": "Canonical",
@@ -52,13 +61,54 @@
       "version": "latest"
     },
     "imageReference": "[variables('osType')]",
-    "computeApiVersion": "2017-03-30",
-    "networkApiVersion": "2017-04-01"
+    "computeApiVersion": "2017-12-01",
+    "networkApiVersion": "2017-10-01"
   },
   "resources": [
     {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[variables('location')]",
+      "properties": {
+          "securityRules": [
+              {
+                  "name": "allowSSH",
+                  "properties": {
+                      "description": "Allow SSH traffic",
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "22",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 1000,
+                      "direction": "Inbound"
+                  }
+              },
+              {
+                  "name": "allowHTTP",
+                  "properties": {
+                      "description": "Allow web traffic",
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "80",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 1001,
+                      "direction": "Inbound"
+                  }
+              }
+          ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]"
+      ],
       "location": "[variables('location')]",
       "apiVersion": "[variables('networkApiVersion')]",
       "properties": {
@@ -71,10 +121,103 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "sku": {
+          "name": "Standard"
+      },
+      "properties": {
+          "publicIPAllocationMethod": "Static",
+          "dnsSettings": {
+              "domainNameLabel": "[parameters('vmssName')]"
+          }
+      }
+    },
+    {
+      "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "name": "[variables('loadBalancerName')]",
+      "location": "[variables('location')]",
+      "sku": {
+          "name": "Standard"
+      },
+      "dependsOn": [
+          "[variables('publicIPAddressName')]"
+      ],
+      "properties": {
+          "frontendIPConfigurations": [
+              {
+                  "name": "LoadBalancerFrontEnd",
+                  "properties": {
+                      "publicIPAddress": {
+                          "id": "[variables('publicIPAddressID')]"
+                      }
+                  }
+              }
+          ],
+          "backendAddressPools": [
+              {
+                  "name": "[variables('bePoolName')]"
+              }
+          ],
+          "probes": [
+            {
+              "name": "tcpProbe",
+              "properties": {
+                "protocol": "tcp",
+                "port": 80,
+                "intervalInSeconds": 5,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "LBRule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "[variables('frontEndIPConfigID')]"
+                },
+                "backendAddressPool": {
+                  "id": "[variables('lbPoolID')]"
+                },
+                "protocol": "tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": false,
+                "idleTimeoutInMinutes": 5,
+                "probe": {
+                  "id": "[variables('lbProbeID')]"
+                }
+              }
+            }
+          ],
+          "inboundNatPools": [
+              {
+                  "name": "[variables('natPoolName')]",
+                  "properties": {
+                      "frontendIPConfiguration": {
+                          "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPortRangeStart": "50000",
+                      "frontendPortRangeEnd": "50100",
+                      "backendPort": "22"
+                  }
+              }
+          ]
       }
     },
     {
@@ -86,7 +229,8 @@
       ],
       "apiVersion": "[variables('computeApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]"
       ],
       "sku": {
         "name": "[variables('vmSize')]",
@@ -95,7 +239,7 @@
       },
       "properties": {
         "upgradePolicy": {
-          "mode": "Manual"
+          "mode": "Automatic"
         },
         "virtualMachineProfile": {
           "storageProfile": {
@@ -122,10 +266,39 @@
                       "properties": {
                         "subnet": {
                           "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'), '/subnets/', variables('subnetName'))]"
-                        }
+                        },
+                        "loadBalancerBackendAddressPools": [
+                          {
+                              "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('bePoolName'))]"
+                          }
+                        ],
+                        "loadBalancerInboundNatPools": [
+                            {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools/', variables('loadBalancerName'), variables('natPoolName'))]"
+                            }
+                        ]
                       }
                     }
                   ]
+                }
+              }
+            ]
+          },
+          "extensionProfile": {
+            "extensions": [
+              {
+                "name": "AppInstall",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0",
+                  "autoUpgradeMinorVersion": true,
+                  "settings": {
+                    "fileUris": [
+                      "https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"
+                    ],
+                    "commandToExecute": "bash automate_nginx.sh"
+                  }
                 }
               }
             ]


### PR DESCRIPTION
@gatneil As discussed, updating sample templates to include load balancer support. To keep these in-line with CLI + PowerShell samples, also using Custom Script Extension to deploy basic web app.

Happy to split these out to new templates so as not to cloud the existing, simpler templates that just highlight how to deploy single-zone or zone-redundant scale sets.